### PR TITLE
feat: Implement and add set_end_pos logic for SimplePlayerMap

### DIFF
--- a/players/group5/player.py
+++ b/players/group5/player.py
@@ -40,5 +40,5 @@ class G5_Player:
                     DOWN = 3
         """
         self.turns += 1
-        self.player_map.update_map(self.turns, current_percept.maze_state)
+        self.player_map.update_map(self.turns, current_percept)
         return constants.UP

--- a/players/group5/player_map.py
+++ b/players/group5/player_map.py
@@ -59,12 +59,12 @@ class PlayerMapInterface(ABC):
         pass
 
     @abstractmethod
-    def update_map(self, turn_num: int, precept: TimingMazeState):  # TODO: check type of maze_state
+    def update_map(self, turn_num: int, percept: TimingMazeState):  # TODO: check type of maze_state
         """Function which updates the map with the given maze state
 
             Args:
                 turn_num (int): Integer representing the current turn number
-                precept (TimingMazeState): TimingMazeState object describing the current state of the visible maze
+                percept (TimingMazeState): TimingMazeState object describing the current state of the visible maze
         """
         pass
 
@@ -182,8 +182,8 @@ class SimplePlayerMap(PlayerMapInterface):
             self._boundaries[constants.DOWN] = door_coordinates[1]
             self._boundaries[constants.UP] = door_coordinates[1] - map_e2e_dist
 
-    def update_map(self, turn_num: int, precept: TimingMazeState):
-        maze_state = precept.maze_state
+    def update_map(self, turn_num: int, percept: TimingMazeState):
+        maze_state = percept.maze_state
 
         cells_seen = set()
         # before = self._door_freqs.copy()
@@ -209,8 +209,8 @@ class SimplePlayerMap(PlayerMapInterface):
         for cell in cells_seen:
             self._cell_seen_count[cell] += 1
 
-        if precept.is_end_visible and self._end_pos is None:
-            self.set_end_pos([precept.end_x, precept.end])
+        if percept.is_end_visible and self._end_pos is None:
+            self.set_end_pos([percept.end_x, percept.end_y])
 
     def get_seen_counts(self, relative_coord: List[List[int]]) -> List[int]:
         return [self._cell_seen_count.get(tuple(self._get_map_coordinates(cell)), 0) for cell in relative_coord]

--- a/players/group5/player_map.py
+++ b/players/group5/player_map.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Set, Tuple
 
 import constants
 from players.group5.door import DoorIdentifier, update_frequency_candidates
+from timing_maze_state import TimingMazeState
 
 
 class PlayerMapInterface(ABC):
@@ -58,12 +59,12 @@ class PlayerMapInterface(ABC):
         pass
 
     @abstractmethod
-    def update_map(self, turn_num: int, maze_state: List[List[int]]):  # TODO: check type of maze_state
+    def update_map(self, turn_num: int, precept: TimingMazeState):  # TODO: check type of maze_state
         """Function which updates the map with the given maze state
 
             Args:
                 turn_num (int): Integer representing the current turn number
-                maze_state (List[List[int]]): 2D list of integers representing the maze state (within the radius) at the given turn
+                precept (TimingMazeState): TimingMazeState object describing the current state of the visible maze
         """
         pass
 
@@ -101,7 +102,7 @@ class SimplePlayerMap(PlayerMapInterface):
         self._real_map_dim = map_dim
         self._map_len = 2 * (map_dim-1) + 1
         self._start_pos = [map_dim-1, map_dim-1]
-        self._end_pos = [None, None]
+        self._end_pos = None
         self._boundaries = [-1, -1, self._map_len, self._map_len]  # LEFT, UP, RIGHT, DOWN (see constants.py)
 
         self.cur_pos = self._start_pos
@@ -119,10 +120,13 @@ class SimplePlayerMap(PlayerMapInterface):
         return self._get_player_relative_coordinates(self._start_pos)
 
     def get_end_pos_if_known(self) -> Tuple[bool, Optional[List[int]]]:
-        if self._end_pos[0] is None:
+        if self._end_pos is None:
             return False, None
         return True, self._get_player_relative_coordinates(self._end_pos)
     
+    def set_end_pos(self, relative_coord: List[int]):
+        self._end_pos = self._get_map_coordinates(relative_coord)
+
     def get_cur_pos(self) -> List[int]:
         # NOTE: this will always return 0,0 for SimplePlayerMap where all output coordinates are relative to cur_pos
         return self._get_player_relative_coordinates(self.cur_pos)
@@ -178,7 +182,9 @@ class SimplePlayerMap(PlayerMapInterface):
             self._boundaries[constants.DOWN] = door_coordinates[1]
             self._boundaries[constants.UP] = door_coordinates[1] - map_e2e_dist
 
-    def update_map(self, turn_num: int, maze_state: List[List[int]]):
+    def update_map(self, turn_num: int, precept: TimingMazeState):
+        maze_state = precept.maze_state
+
         cells_seen = set()
         # before = self._door_freqs.copy()
         for door in maze_state:
@@ -202,6 +208,9 @@ class SimplePlayerMap(PlayerMapInterface):
         # update seen count
         for cell in cells_seen:
             self._cell_seen_count[cell] += 1
+
+        if precept.is_end_visible and self._end_pos is None:
+            self.set_end_pos([precept.end_x, precept.end])
 
     def get_seen_counts(self, relative_coord: List[List[int]]) -> List[int]:
         return [self._cell_seen_count.get(tuple(self._get_map_coordinates(cell)), 0) for cell in relative_coord]


### PR DESCRIPTION
Once end_pos is visible in the drone view, it is added to the playermap and can be retrieved by user-relative coordinates at any time through `get_end_pos_if_known`